### PR TITLE
Android autoupdate and stackTraces

### DIFF
--- a/model/androidVersion.js
+++ b/model/androidVersion.js
@@ -1,0 +1,9 @@
+var mongoose = require('mongoose')
+  , Schema = mongoose.Schema;
+
+var AndroidVersion = new Schema({
+  version: {type: String},
+  created: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('AndroidVersion', AndroidVersion);

--- a/model/stackTrace.js
+++ b/model/stackTrace.js
@@ -1,0 +1,10 @@
+var mongoose = require('mongoose')
+  , Schema = mongoose.Schema;
+
+var StackTrace = new Schema({
+  androidVersion: {type: Schema.Types.ObjectId, ref: 'AndroidVersion'},
+  trace: String,
+  created: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('StackTrace', StackTrace);

--- a/routes/androidVersion.js
+++ b/routes/androidVersion.js
@@ -1,0 +1,39 @@
+var ObjectId = require('mongoose').Types.ObjectId;
+var AndroidVersion = require('../model/androidVersion');
+
+/*
+* Adds a new version as the latest for android.
+*
+* This function should be unnaccessible to the public in the prod environment.
+*/
+exports.postAndroidVersion = function(req, res) {
+  var versionData = req.body.version;
+  var secret = req.body.secret;
+  if(secret!=="sisCalendar"){
+    return res.send(401,{error:"Not Authorized"});
+  }
+  if(!versionData){
+    return res.send(500,{error:"No version given"});
+  }
+  var androidVersion = new AndroidVersion({version:versionData});
+  androidVersion.save(function(err, data){
+    if(err){
+      return res.send(500,{error:"Couldn't save android version"});
+    }
+    return res.send(200,data);
+  });
+};
+
+/*
+* Endpoint for the android app to know if it has the latest version.
+* This will allow the android app to prompt for an update and automatically
+* bring them to Dropbox and later on to the Play Store.
+*/
+exports.getLatestAndroidVersion = function(req,res){
+  AndroidVersion.findOne({}, {}, { sort: { 'created' : -1 } }, function(err, version){
+    if(err || !version){
+      return res.send(500,{error:"Couldn't find any android versions"});
+    }
+    return res.send(200,{version:version.version});
+  });
+}

--- a/routes/stackTrace.js
+++ b/routes/stackTrace.js
@@ -1,0 +1,50 @@
+var ObjectId = require('mongoose').Types.ObjectId;
+var StackTrace = require('../model/stackTrace');
+var AndroidVersion = require('../model/androidVersion');
+
+/*
+* The android app has the ability to send stack traces when it crashes.
+* This is the endpoint to which it sends those stack traces.
+*
+* NO user data is sent with the stack trace!
+*/
+exports.postStackTrace = function(req, res) {
+  var text = req.body.stacktrace;
+  var versionData = req.body.package_version;
+  if(!text || !versionData){
+    return res.send(500,{error:"Error retrieving post data"});
+  }
+  AndroidVersion.findOne({version:versionData},function(err,androidVersion){
+    if(err || !androidVersion){
+      return res.send(500,{error:"No record of that android version"});
+    }
+    var stackTrace = new StackTrace({androidVersion:androidVersion,trace:text});
+    stackTrace.save(function(err,doc){
+      if(err){
+        return res.send(500,{error:"Couldn't save stack Trace"});
+      }
+      return res.send(200,doc);
+    });
+  });
+};
+
+/*
+* Retrieve stack traces for a given android version.
+* Should become inaccessible to the public when going to production.
+*/
+exports.getStackTraces = function(req,res){
+
+  var androidVersion = req.params.version;
+  console.log(androidVersion);
+  AndroidVersion.findOne({version:androidVersion},function(err,versionObject){
+    if(err || !versionObject){
+      return res.send(500,{error:"Couldn't find android version"});
+    }
+    StackTrace.find({androidVersion:versionObject},function(err,traces){
+      if(err || traces.length==0){
+        return res.send(500,{error:"Couldn't find any stackTraces"});
+      }
+      return res.send(200,traces);
+    });
+  });
+}

--- a/server.js
+++ b/server.js
@@ -107,6 +107,8 @@ var userRoutes = require('./routes/user');
 var groupRoutes = require('./routes/group');
 var messageRoutes = require('./routes/message');
 var deviceRoutes = require('./routes/device');
+var stackTraceRoutes = require('./routes/stackTrace');
+var androidVersionRoutes = require('./routes/androidVersion');
 
 app.post('/login', userRoutes.loginPOST);
 app.delete('/logout', ensureAuthenticated, userRoutes.logout);
@@ -125,6 +127,13 @@ app.put('/group/:id/settings', ensureAuthenticated, groupRoutes.changeSettings);
 
 app.get('/user/device', ensureAuthenticated, deviceRoutes.getDevices);
 app.post('/user/device', ensureAuthenticated, deviceRoutes.postDevice);
+
+
+app.post('/stackTrace',stackTraceRoutes.postStackTrace);
+app.get('/stackTrace/:version/',stackTraceRoutes.getStackTraces);
+
+app.post('/androidVersion',androidVersionRoutes.postAndroidVersion);
+app.get('/androidVersion/latest',androidVersionRoutes.getLatestAndroidVersion);
 
 
 // Simple route middleware to ensure user is authenticated.


### PR DESCRIPTION
This will add 4 endpoints for the android application.

POST /androidVersion : This will allow me to add a new android version as the latest.

GET /androidVersion/latest : This is the endpoint that android calls to check the latest android version. In app I can have a popup which will automatically bring them to dropbox or the Play Store to download the update.

POST /stackTrace : I have a library that will catch errors in the app before it crashes and sends the data as a post request. This is the endpoint I will use to capture these stack traces.

GET /stackTrace/:version/ This will get all stack traces for a specific version of android. This will be helpful when Jared & others are having crashing issues.

What do you think?
